### PR TITLE
Upgrade Scala version to 2.10.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.10.1</version>
+      <version>2.10.7</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>2.9.2</version>
+      <version>2.10.7</version>
     </dependency>
     <dependency>
       <groupId>com.101tec</groupId>


### PR DESCRIPTION
This fixes CVE-2017-15288. Before 2.10.7, the compilation daemon in
Scala before 2.10.7, 2.11.x before 2.11.12, and 2.12.x before 2.12.4
uses weak permissions for private files in
/tmp/scala-devel/${USER:shared}/scalac-compile-server-port, which
allows local users to write to arbitrary class files and consequently
gain privileges.

https://nvd.nist.gov/vuln/detail/CVE-2017-15288
